### PR TITLE
fix: 빌드 관리 도구 변경

### DIFF
--- a/monitoring/build.gradle
+++ b/monitoring/build.gradle
@@ -19,7 +19,7 @@ repositories {
 dependencies {
     // Spring Cloud dependencies
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-hystrix-dashboard'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 
     // Test dependencies
     testImplementation 'org.springframework.boot:spring-boot-starter-test'


### PR DESCRIPTION
**monitoring 모듈**
- Hystrix는 현재 지원되지 않는 상태이므로 Resilience4j 기반 대시보드로 대체함