### PR TITLE
Fix/#24/turbine stream service 의존성 최신화

### DIFF
--- a/turbine-stream-service/build.gradle
+++ b/turbine-stream-service/build.gradle
@@ -15,7 +15,6 @@ repositories {
 dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-turbine-stream'
     implementation 'org.springframework.cloud:spring-cloud-starter-stream-rabbit'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/turbine-stream-service/src/main/java/com/piggymetrics/turbine/TurbineStreamServiceApplication.java
+++ b/turbine-stream-service/src/main/java/com/piggymetrics/turbine/TurbineStreamServiceApplication.java
@@ -3,10 +3,8 @@ package com.piggymetrics.turbine;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-import org.springframework.cloud.netflix.turbine.stream.EnableTurbineStream;
 
 @SpringBootApplication
-@EnableTurbineStream
 @EnableDiscoveryClient
 public class TurbineStreamServiceApplication {
 


### PR DESCRIPTION
이후 진행할 

Hystrix -> Resilience4j 작업을 위해 tubrine-stream-service는 삭제할 예정 입니다.