### PR TITLE
Fix: 환율 api 검색 날짜 수정

### DIFF
--- a/account-service/src/main/java/com/piggymetrics/account/domain/Currency.java
+++ b/account-service/src/main/java/com/piggymetrics/account/domain/Currency.java
@@ -2,7 +2,7 @@ package com.piggymetrics.account.domain;
 
 public enum Currency {
 
-	USD, EUR, RUB, KRW;
+	USD, EUR, KRW, JPY;
 
 	public static Currency getDefault() {
 		return KRW;

--- a/statistics-service/src/main/java/com/piggymetrics/statistics/config/ResourceServerConfig.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/config/ResourceServerConfig.java
@@ -30,7 +30,7 @@ public class ResourceServerConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(auth -> auth
-                .requestMatchers(HttpMethod.POST, "/api/v1/account", "api/v1/statistics/rates**").permitAll() // 회원가입은 허용
+                .requestMatchers(HttpMethod.POST, "/api/v1/account", "api/v1/statistics/rates/**").permitAll() // 회원가입은 허용
                 .requestMatchers("/", "/demo").permitAll() // "/" 및 "/demo" 경로는 인증 불필요
                 .anyRequest().authenticated()             // 나머지는 인증 필요
         );

--- a/statistics-service/src/main/java/com/piggymetrics/statistics/domain/Currency.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/domain/Currency.java
@@ -2,7 +2,7 @@ package com.piggymetrics.statistics.domain;
 
 public enum Currency {
 
-	USD, EUR, RUB, KRW;
+	USD, EUR, KRW, JPY;
 
 	public static Currency getBase() {
 		return KRW;

--- a/statistics-service/src/main/java/com/piggymetrics/statistics/service/ExchangeRatesService.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/service/ExchangeRatesService.java
@@ -9,6 +9,7 @@ import com.piggymetrics.statistics.domain.ExchangeRatesContainer.ExchangeRate;
 import com.piggymetrics.statistics.exception.CustomException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -54,8 +55,11 @@ public class ExchangeRatesService {
 	public Map<Currency, BigDecimal> getCurrentRates() {
 
 		if (exchangeRates == null || exchangeRates.isEmpty()) {
-			String today = LocalDate.now().toString().replace("-", "");
-			exchangeRates = client.getRates(authKey, today, "AP01");
+			LocalDate now = LocalDate.now();
+			LocalDate closestPastWeekday = getClosestPastWeekday(now);
+
+			String searchDate = closestPastWeekday.toString().replace("-", "");
+			exchangeRates = client.getRates(authKey, searchDate, "AP01");
 			log.info("Exchange rates updated: {}", exchangeRates);
 		}
 
@@ -84,6 +88,21 @@ public class ExchangeRatesService {
 		BigDecimal ratio = fromRate.divide(toRate, 4, RoundingMode.HALF_UP);
 
 		return amount.multiply(ratio);
+	}
+
+	private LocalDate getClosestPastWeekday(LocalDate date) {
+		DayOfWeek dayOfWeek = date.getDayOfWeek();
+
+		switch (dayOfWeek) {
+			case MONDAY: // 월요일이면 금요일로 이동
+				return date.minusDays(3);
+			case SUNDAY: // 일요일이면 금요일로 이동
+				return date.minusDays(2);
+			case SATURDAY: // 토요일이면 금요일로 이동
+				return date.minusDays(1);
+			default: // 평일(화~금)은 하루 전으로 이동
+				return date.minusDays(1);
+		}
 	}
 
 }


### PR DESCRIPTION
환율 api 검색은 평일에만 가능하다는 점을 고려해 가장 가까운 평일로 검색할 수 있도록 수정함

검색 날짜 계산 로직
```java
private LocalDate getClosestPastWeekday(LocalDate date) {
		DayOfWeek dayOfWeek = date.getDayOfWeek();

		switch (dayOfWeek) {
			case MONDAY: // 월요일이면 금요일로 이동
				return date.minusDays(3);
			case SUNDAY: // 일요일이면 금요일로 이동
				return date.minusDays(2);
			case SATURDAY: // 토요일이면 금요일로 이동
				return date.minusDays(1);
			default: // 평일(화~금)은 하루 전으로 이동
				return date.minusDays(1);
		}
	}
```


2024.1.5(일)에 요청했을 때 성공하는 스크린샷
<img width="1145" alt="스크린샷 2025-01-05 오후 10 11 10" src="https://github.com/user-attachments/assets/828f4c3a-610c-4225-87af-7ba7a4fdd5a1" />
