### PR TITLE
fix: statistics-service 잘못된 임포트 삭제

### DIFF
--- a/statistics-service/src/main/java/com/piggymetrics/statistics/StatisticsApplication.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/StatisticsApplication.java
@@ -1,6 +1,5 @@
 package com.piggymetrics.statistics;
 
-import com.piggymetrics.statistics.config.DisableSSL;
 import com.piggymetrics.statistics.repository.converter.DataPointIdReaderConverter;
 import com.piggymetrics.statistics.repository.converter.DataPointIdWriterConverter;
 import feign.Client;


### PR DESCRIPTION
존재하지 않는 클래스에 대한 Import가 되어 있어 오류 발생, 해당 임포트를 삭제함