### PR TITLE
fix: USD 통계 계산 문제 해결

### DIFF
--- a/gateway/src/main/resources/static/js/launch.js
+++ b/gateway/src/main/resources/static/js/launch.js
@@ -143,9 +143,9 @@ $(window).load(function(){
 	}
 
     $.getJSON("api/v1/statistics/rates/default", function( data ) {
-        global.krw = 1 / data.KRW;
-        global.usd = 1 / data.USD;
-    });
+        global.krw = data.KRW;
+        global.usd = data.USD;
+    });율
 
 	var account = getCurrentAccount();
 


### PR DESCRIPTION
- 1 / USD 로 환율이 계산되어 변수에 저장되어 잘못된 converted를 반화하는 문제 해결. ex) 1450원으로 그대로 들어가지 않고 1/1450원으로 계산하게 되는 문제 해결

1/USD -> USD 그대로 들어가도록 수정함
- 기존 프로젝트에서 1/USD라고 변수를 썼는데, api 변환등의 과정을 거치면서 뭔가 계산이 반대로 되었던 것 같음...

### 수입 50000원/MONTH, 지출 1달러/DAY saving 시 화면
<img width="1150" alt="스크린샷 2025-01-10 오전 11 36 47" src="https://github.com/user-attachments/assets/ee2e3160-b634-4b13-a503-b3d915dac6bd" />
KRW 기준 지출: 1일 1450원, 한달 1450*30일 정도로 제대로 출력됨. spare는 한달 50000원 - 1450*30 = 약 5800원

<img width="1153" alt="스크린샷 2025-01-10 오전 11 37 04" src="https://github.com/user-attachments/assets/cb180c78-1514-4a2e-80b6-3159aebcde5f" />
지출만 USD로 확인했을 때 지출 1달러/DAY, 30달러/MONTH 로 정확하게 출력. /YEAR도 1달러*30일(31일) = 약 370달러로 출력
